### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @softservedata
+* softservedata


### PR DESCRIPTION
switched rule from a GitHub team to an individual user omitting the '@' symbol

as long as CODEOWNERS is located in .github folder, its rules applied to main branch only otherwise move the file to root